### PR TITLE
feat: INFRA-860 utilisation de journald par default pour postgres

### DIFF
--- a/postgres-load-balancer/user_data.yaml.tpl
+++ b/postgres-load-balancer/user_data.yaml.tpl
@@ -56,4 +56,4 @@ runcmd:
   - apt-get install -y docker-ce docker-ce-cli containerd.io
 %{ endif ~}
   - systemctl enable docker
-  - docker ${container_params.config} run -d --restart=always --name=postgres_load_balancer --network=host -v /opt/haproxy:/usr/local/etc/haproxy:ro -v /opt/patroni:/opt/patroni/:ro ${container_params.fluentd} haproxy:2.2.14
+  - docker ${container_params.config} run -d --restart=always --name=postgres_load_balancer --network=host -v /opt/haproxy:/usr/local/etc/haproxy:ro -v /opt/patroni:/opt/patroni/:ro %{ if container_params.fluentd != "" }${container_params.fluentd}%{ else }--log-driver=journald%{ endif } haproxy:2.2.14


### PR DESCRIPTION
Cette PR change le comportement par default lorsqu'aucune configuration fluentd n'est presente afin d'utiliser journald pour le management des logs du container.

Ce changement permet à docker de déléger la gestion des logs et de bénéficier de la centralisation et du management de journald